### PR TITLE
Set scripts in bin to executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,6 +236,7 @@ PROJECT_FILES += ${PROJECT_TOOLING}
 PROJECT_FILES += ${PROJECT_STARTER}
 
 project: ${PROJECT_FILES}
+  find bin -type f -exec chmod 744 {} +
 
 ${PROJECT_FILES}:
   @mkdir -p $(dir $@)

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ make project
 # Build project
 make build
 # Run server
-./bin/server
+./bin/run/server
 # Invoke default server settings starter function
 open http://localhost:3000/hello/world
 ```


### PR DESCRIPTION
Add step to `project` target to ensure that all files within `bin` are
executable to prevent script failures in `build` target.

Update `README` to reflect updated `bin` directory structure.