### PR TITLE
Improve Compatibility with macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ define newline
 endef
 
 # The time, now
-now = $(shell date --utc --rfc-3339=seconds | sed 's/ /T/')
+now = $(shell date -u '+%Y-%m-%d %T%z' | sed 's/ /T/')
 
 # Converts comma-delimited env vars into space-delimited lists
 split-list = $(strip $(subst $(comma),$(space),$1))

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ FUNCTIONS ?= $(shell \
     -iname "*.py" \
     ! -iname "__init__.py" \
     ! -path "__pycache__" \
-    -printf "%p " \
+    -print \
 )
 # Which files to assume are library files
 LIBRARIES ?= $(shell \
@@ -83,7 +83,7 @@ LIBRARIES ?= $(shell \
     -type f \
     -iname "*.py" \
     ! -path "__pycache__" \
-    -printf "%p " \
+    -print \
 )
 
 

--- a/Makefile
+++ b/Makefile
@@ -278,7 +278,7 @@ BUILD_FUNCTIONS = $(addsuffix /function.py,${BUILD_FUNCTION_DIRS})
 build-functions: ${BUILD_FUNCTIONS}
 
 ${BUILD_FUNCTIONS}: ${BUILD_FUNCTION_DIR}/%/function.py: functions/%.py | ${BUILD_FUNCTION_DIR}/% functions
-  cp -fu $< $@
+  cp -f $< $@
 
 
 # BUILD subcommand: make build-libraries
@@ -301,7 +301,7 @@ build-libraries: ${BUILD_FUNCTION_LIBRARIES}
 define RULE_BUILD_FUNCTION_LIBRARIES
 $1/%.py: lib/%.py | $1 lib
   mkdir -p $$(dir $$@)
-  cp -fu $$< $$@
+  cp -f $$< $$@
 endef
 $(foreach build_function_dir,${BUILD_FUNCTION_DIRS}, \
   $(eval $(call RULE_BUILD_FUNCTION_LIBRARIES,${build_function_dir})) \
@@ -325,7 +325,7 @@ ${BUILD_DEPENDENCIES}: requirements.txt | ${BUILD_DIR}/ bin/install/deps
 
 define RULE_UPDATE_FUNCTION_DEPENDENCIES
 $1/%: ${BUILD_DEPENDENCIES}/% | $1
-  cp -afu $$< $$@
+  cp -af $$< $$@
   touch $$@
 endef
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ packages from homebrew:
 
 ```bash
 brew install make --with-default-names
-brew install coreutils
 brew install gnu-sed --with-default-names
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ packages from homebrew:
 
 ```bash
 brew install make --with-default-names
-brew install findutils --with-default-names
 brew install coreutils
 brew install gnu-sed --with-default-names
 ```


### PR DESCRIPTION
These changes remove the necessity of installing `findutils` and `coreutils` from Homebrew while on macOS.

I made an attempt at trying to get rid of GNU `sed` as well, but it seemed to be more trouble than it was worth. Similarly, given the extreme differences between `make` on macOS vs GNU/Linux, I think we should keep that as an install requirement as well. 

Given that this reduces the set of custom tools to just two, I am much less worried about the potential for breakage of things expecting the macOS version. If we still are looking to go further, I think the suggestion made in #1 about setting up overridable variables which can be set from the shell when invoking `make`.