### PR TITLE
Resolve ZIP change detection bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -342,11 +342,23 @@ BUILD_SUBCOMMANDS += build-packages
 BUILD_PACKAGES = $(addsuffix .zip,$(call dir-merge,${BUILD_FUNCTION_DIR},$(call fun-name-from-dir,${FUNCTION_DIRS})))
 build-packages: ${BUILD_PACKAGES}
 
+FUNDIR = functions
+FUNSTRUCTURE := $(shell find $(FUNDIR) -type d)
+FUNFILES := $(addsuffix /*,$(FUNSTRUCTURE))
+FUNFILES := $(wildcard $(FUNFILES))
+FUNFILES := $(filter %.py,$(FUNFILES))
+
+LIBDIR = lib
+LIBSTRUCTURE := $(shell find $(LIBDIR) -type d)
+LIBFILES := $(addsuffix /*,$(LIBSTRUCTURE))
+LIBFILES := $(wildcard $(LIBFILES))
+LIBFILES := $(filter %.py,$(LIBFILES))
+
 define RULE_BUILD_FUNCTION_PACKAGE
 # Zip func dir ($2) into functions folder, named ($1) after function 
-${BUILD_FUNCTION_DIR}/$1.zip: | ${BUILD_FUNCTION_DIR} ${BUILD_FUNCTION_DIR}/$2
+${BUILD_FUNCTION_DIR}/$1.zip: $(FUNFILES) $(LIBFILES) | ${BUILD_FUNCTION_DIR} ${BUILD_FUNCTION_DIR}/$2
   cd ${BUILD_FUNCTION_DIR}/$2; \
-  zip -roq9 -u $$(abspath $$@) * \
+  zip -rq9 $$(abspath $$@) * \
     -x function.yml \
     -x **/*.pyc \
     -x **/__pycache__/ \


### PR DESCRIPTION
Add function files and library files to the prerequisites list for the
ZIP target.

Update ZIP target `zip` invocation to use neither the update flag (`-u`)
nor the set last modified time to oldest file in the archive (`-o`).
Previously the ZIP file would always be reproduced due to having a last
modified date older than other files it depends on.

The prerequisites need to be tightened on the ZIP target as right now it
is rebuilding all the ZIP packages when any of the code files change,
rather than the ones belonging to an individual package.

Resolves: #5